### PR TITLE
Add Beego ORM in the benchmark suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Benchmark Output:
 
     PASS
     BenchmarkNative   100000         13476 ns/op         376 B/op         14 allocs/op
+    BenchmarkBeego     50000         32154 ns/op        1813 B/op         74 allocs/op
     BenchmarkSqlX     100000         16334 ns/op         537 B/op         17 allocs/op
     BenchmarkDotSQL   100000         13361 ns/op         376 B/op         14 allocs/op
     BenchmarkSqrl      50000         29306 ns/op        2564 B/op         53 allocs/op


### PR DESCRIPTION
After shopping a bit around I saw that Beego.ORM seems to be one of the most efficient Go ORM (don't take my word for that, I'm a new gopher)

Anyway it might be a good idea to add benchmarks for Beego here.
It doesnt do too bad considering that it's quite a neat/complete ORM, I guess we would need to tests different type operations to compare them realistically.